### PR TITLE
Add a common file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Now that your bot's account has been added to the server(s) you want it in, you 
 ```
 TOKEN=BOT_TOKEN
 ADMINS=SNOWFLAKE,SNOWFLAKE,...
+PREFIX=!
 ```
 where `BOT_TOKEN` is the token (your bot's "password") found on the bot tab of your application. After that run `npm i --production` to install dependencies (exclude the `--production` flag if you plan to contribute to Porygon-Z so that developer dependencies are installed too). Meanwhile `OWNERS` is a comma serpated list of discord user snowflakes. You can get a user's snowflake by enabling developer mode in your discord account's user settings and then right clicking the user and selecting `Copy ID` from the dropdown. Owners will bypass all permission checks on all servers.
 After that running `node bot` should start your bot up.

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,9 +8,8 @@
  */
 import fs = require('fs');
 import Discord = require('discord.js');
+import { prefix, ID, toID } from './common';
 import { BaseCommand } from './command_base';
-
-export type ID = '' | string & {__isID: true};
 
 interface Constructable<T> {
 	new(message: Discord.Message): T;
@@ -20,19 +19,7 @@ interface commandModule {
 	[key: string]: Constructable<BaseCommand> | string[];
 }
 
-/**
- * toID - Turns anything into an ID (string with only lowercase alphanumeric characters)
- * @param {any} text
- */
-export function toID(text: any): ID {
-	if (text && text.id) text = text.id;
-	if (typeof text !== 'string' && typeof text !== 'number') return '';
-	return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
-}
-
 const client = new Discord.Client();
-// The prefix to all bot commands
-export const prefix = '!';
 // Map of Command Classes - Build before use
 export const commands = new Discord.Collection<ID, Constructable<BaseCommand> | ID>();
 

--- a/src/command_base.ts
+++ b/src/command_base.ts
@@ -5,7 +5,7 @@
  * execution in general.
  */
 import Discord = require('discord.js');
-import { prefix, ID, toID } from './app';
+import { prefix, ID, toID } from './common';
 export type DiscordChannel = Discord.TextChannel|Discord.DMChannel|Discord.GroupDMChannel;
 export type aliasList = {[key: string]: string[]};
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -3,7 +3,7 @@
  * Basic development related commands, may rename later.
  */
 import Discord = require('discord.js');
-import { prefix, ID, toID } from '../app';
+import { prefix, ID, toID } from '../common';
 import { BaseCommand, aliasList, DiscordChannel } from '../command_base';
 
 export const aliases: aliasList = {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,13 @@
+export type ID = '' | string & {__isID: true};
+
+// The prefix to all bot commands
+export const prefix = process.env.PREFIX || '!';
+
+/**
+ * toID - Turns anything into an ID (string with only lowercase alphanumeric characters)
+ */
+export function toID(text: any): ID {
+	if (text && text.id) return text.id
+	if (typeof text !== 'string' && typeof text !== 'number') return '';
+	return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
+}


### PR DESCRIPTION
This moves ID, prefix, and toID from `app.ts` to `common.ts`,
because none of these types/function/variables should be in
an "app" file whose main purpose is to get the bot up and
running.

I vaguely recall a discussion in the Smogon Development Discord server
where global variables where decided against, so this seems like a
good compromise.