### PR TITLE
Add abstraction for SQL databases

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "discord.js": "^12.1.1",
     "dotenv": "^8.1.0",
     "eslint-plugin-jest": "^24.3.5",
-    "pg": "^7.12.1",
+    "pg": "^8.0.3",
+    "pg-mem": "^1.9.6",
     "postgrator": "^4.0.1",
+    "sqlutils": "^1.2.1",
     "typescript": "^4.1.5"
   },
   "devDependencies": {

--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -4,7 +4,7 @@
  * channel activity monitors.
  */
 import Discord = require('discord.js');
-import {prefix, toID, pgPool} from '../common';
+import {prefix, toID, database} from '../common';
 import {BaseCommand, ReactionPageTurner, DiscordChannel, IAliasList} from '../command_base';
 
 const ENGLISH_MONTH_NAMES = [
@@ -200,9 +200,7 @@ export class Leaderboard extends BaseCommand {
 		}
 
 		query += ' GROUP BY u.name, u.discriminator ORDER BY SUM(l.lines) desc;';
-		const res = await pgPool.query(query, args);
-
-		return res.rows;
+		return database.queryWithResults(query, args);
 	}
 
 	async execute() {
@@ -269,9 +267,7 @@ export class ChannelLeaderboard extends BaseCommand {
 		}
 
 		query += ' GROUP BY ch.channelname ORDER BY SUM(cl.lines) desc;';
-		const res = await pgPool.query(query, args);
-
-		return res.rows;
+		return database.queryWithResults(query, args);
 	}
 
 	async execute() {
@@ -333,9 +329,7 @@ export class Linecount extends BaseCommand {
 		let query = `SELECT ${key ? key + ' AS time, ' : ''}SUM(l.lines) FROM lines l WHERE l.serverid = $1 AND l.userid = $2`;
 		if (key) query += ` GROUP BY ${key} ORDER BY ${key} desc;`;
 		const args = [this.guild.id, id];
-		const res = await pgPool.query(query, args);
-
-		return res.rows;
+		return database.queryWithResults(query, args);
 	}
 
 	async execute() {
@@ -401,9 +395,7 @@ export class ChannelLinecount extends BaseCommand {
 		query += ' WHERE ch.serverid = $1 AND ch.channelid = $2';
 		if (key) query += ` GROUP BY ${key} ORDER BY ${key} desc;`;
 		const args = [this.guild.id, id];
-		const res = await pgPool.query(query, args);
-
-		return res.rows;
+		return database.queryWithResults(query, args);
 	}
 
 	async execute() {

--- a/src/commands/moderation.ts
+++ b/src/commands/moderation.ts
@@ -4,7 +4,7 @@
  * and administrators.
  */
 import Discord = require('discord.js');
-import {prefix, toID, pgPool} from '../common';
+import {prefix, toID, database} from '../common';
 import {BaseCommand} from '../command_base';
 import {client} from '../app';
 
@@ -37,7 +37,7 @@ export class Whois extends BaseCommand {
 	}
 
 	async execute() {
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('KICK_MEMBERS'))) return this.errorReply('Access Denied.');
 
 		const user = this.getUser(this.target);
@@ -98,13 +98,13 @@ export class WhoHas extends BaseCommand {
 	}
 
 	async execute() {
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('KICK_MEMBERS'))) return this.errorReply('Access Denied.');
 
 		if (!this.target.trim()) return this.reply(WhoHas.help());
 
 		const role = await this.getRole(this.target, true);
-		if (!role) return this.errorReply(`The role "${this.target}" was not found. Role names are Case Sensetive - Make sure your typing the role name exactly as it appears.`);
+		if (!role) return this.errorReply(`The role "${this.target}" was not found. Role names are case sensitive: make sure you're typing the role name exactly as it appears.`);
 
 		const embed: Discord.MessageEmbedOptions = {
 			color: 0x6194fd,
@@ -177,7 +177,7 @@ abstract class StickyCommand extends BaseCommand {
 		query = query.slice(0, query.length - 2);
 		query += ');';
 
-		await pgPool.query(query, args);
+		await database.query(query, args);
 	}
 }
 
@@ -188,7 +188,7 @@ export class Sticky extends StickyCommand {
 
 	async execute() {
 		if (!toID(this.target)) return this.reply(Sticky.help());
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('MANAGE_ROLES'))) return this.errorReply('Access Denied');
 		const bot = this.guild.me ? this.guild.me.user : null;
 		if (!bot) throw new Error('Bot user not found.');
@@ -216,34 +216,23 @@ export class Sticky extends StickyCommand {
 		}
 
 		// Validate @role is not already sticky (database query)
-		this.worker = await pgPool.connect();
-		const res = await this.worker.query('SELECT sticky FROM servers WHERE serverid = $1', [this.guild.id]);
-		if (!res.rows.length) {
+		const res = await database.queryWithResults('SELECT sticky FROM servers WHERE serverid = $1', [this.guild.id]);
+		if (!res.length) {
 			throw new Error(`Unable to find sticky roles in database for guild: ${this.guild.name} (${this.guild.id})`);
 		}
-		const stickyRoles: string[] = res.rows[0].sticky;
+		const stickyRoles: string[] = res[0].sticky;
 
 		if (stickyRoles.includes(role.id)) {
-			this.releaseWorker();
 			return this.errorReply('That role is already sticky!');
 		}
 
 		// ---VALIDATION LINE---
 		// Make @role sticky (database update)
 		stickyRoles.push(role.id);
-		try {
-			await this.worker.query('BEGIN');
-			await this.worker.query('UPDATE servers SET sticky = $1 WHERE serverid = $2', [stickyRoles, this.guild.id]);
-			// Find all users with @role and perform database update so role is now sticky for them
-			await this.massStickyUpdate(role);
-			await this.worker.query('COMMIT');
-			this.releaseWorker();
-		} catch (e) {
-			await this.worker.query('ROLLBACK');
-			this.releaseWorker();
-			throw e;
-		}
-		// Return success message
+		await database.withinTransaction([
+			{statement: 'UPDATE servers SET sticky = $1 WHERE serverid = $2', args: [stickyRoles, this.guild.id]},
+		]);
+		await this.massStickyUpdate(role); // I hope this works...
 		await this.reply(`The role "${role.name}" is now sticky! Members who leave and rejoin the server with this role will have it reassigned automatically.`);
 	}
 
@@ -255,12 +244,12 @@ export class Sticky extends StickyCommand {
 
 	static async init(): Promise<void> {
 		// This init is for all four sticky role commands
-		const res = await pgPool.query('SELECT serverid, sticky FROM servers');
-		if (!res.rows.length) return; // No servers?
+		const res = await database.queryWithResults('SELECT serverid, sticky FROM servers');
+		if (!res.length) return; // No servers?
 
-		for (const {sticky: stickyRoles, serverid} of res.rows) {
+		for (const {sticky: stickyRoles, serverid} of res) {
 			// Get list of users and their sticky roles
-			const serverRes = await pgPool.query('SELECT userid, sticky FROM userlist WHERE serverid = $1', [serverid]);
+			const serverRes = await database.queryWithResults('SELECT userid, sticky FROM userlist WHERE serverid = $1', [serverid]);
 			const server = client.guilds.cache.get(serverid);
 			if (!server) {
 				console.error('ERR NO SERVER FOUND');
@@ -268,7 +257,7 @@ export class Sticky extends StickyCommand {
 			}
 			await server.members.fetch();
 
-			for (const {userid, sticky} of serverRes.rows) {
+			for (const {userid, sticky} of serverRes) {
 				const member = server.members.cache.get(userid);
 				if (!member) continue; // User left the server, but has not re-joined so we can't do anything but wait.
 				// Check which of this member's roles are sticky
@@ -277,7 +266,7 @@ export class Sticky extends StickyCommand {
 				// Compare member's current sticky roles to the ones in the database. If they match, do nothing.
 				const userStickyRoles: string[] = sticky;
 				if (!roles.length && userStickyRoles.length) {
-					await pgPool.query(
+					await database.query(
 						'UPDATE userlist SET sticky = $1 WHERE serverid = $2 AND userid = $3',
 						[roles, serverid, member.user.id]
 					);
@@ -287,7 +276,7 @@ export class Sticky extends StickyCommand {
 				if (roles.every(r => userStickyRoles.includes(r))) continue;
 
 				// Update database with new roles
-				await pgPool.query(
+				await database.queryWithResults(
 					'UPDATE userlist SET sticky = $1 WHERE serverid = $2 AND userid = $3',
 					[roles, serverid, member.user.id]
 				);
@@ -303,7 +292,7 @@ export class Unsticky extends StickyCommand {
 
 	async execute() {
 		if (!toID(this.target)) return this.reply(Unsticky.help());
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('MANAGE_ROLES'))) return this.errorReply('Access Denied');
 
 		// Validate @role exists
@@ -319,33 +308,24 @@ export class Unsticky extends StickyCommand {
 		}
 
 		// Validate @role is sticky (database query)
-		this.worker = await pgPool.connect();
-		const res = await this.worker.query('SELECT sticky FROM servers WHERE serverid = $1', [this.guild.id]);
-		if (!res.rows.length) {
+		const res = await database.queryWithResults('SELECT sticky FROM servers WHERE serverid = $1', [this.guild.id]);
+		if (!res.length) {
 			throw new Error(`Unable to find sticky roles in database for guild: ${this.guild.name} (${this.guild.id})`);
 		}
-		const stickyRoles: string[] = res.rows[0].sticky;
+		const stickyRoles: string[] = res[0].sticky;
 
 		if (!stickyRoles.includes(role.id)) {
-			this.releaseWorker();
 			return this.errorReply('That role is not sticky!');
 		}
 
 		// ---VALIDATION LINE---
 		// Make @role not sticky (database update)
 		stickyRoles.splice(stickyRoles.indexOf(role.id), 1);
-		try {
-			await this.worker.query('BEGIN');
-			await this.worker.query('UPDATE servers SET sticky = $1 WHERE serverid = $2', [stickyRoles, this.guild.id]);
-			// Find all users with @role and perform database update so role is no longer sticky for them
-			await this.massStickyUpdate(role, true);
-			await this.worker.query('COMMIT');
-			this.releaseWorker();
-		} catch (e) {
-			await this.worker.query('ROLLBACK');
-			this.releaseWorker();
-			throw e;
-		}
+		await database.withinTransaction([
+			{statement: 'UPDATE servers SET sticky = $1 WHERE serverid = $2', args: [stickyRoles, this.guild.id]},
+		]);
+		await this.massStickyUpdate(role, true);
+
 		// Return success message
 		await this.reply(`The role "${role.name}" is no longer sticky.`);
 	}
@@ -363,20 +343,16 @@ export class EnableLogs extends BaseCommand {
 	}
 
 	async execute() {
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('MANAGE_GUILD'))) return this.errorReply('Access Denied');
-		this.worker = await pgPool.connect();
 
-		const res = await this.worker.query('SELECT logchannel FROM servers WHERE serverid = $1', [this.guild.id]);
-		if (res.rows[0].logchannel) {
-			return this.errorReply(`This server is already set up to log to <#${res.rows[0].logchannel}>.`);
+		const res = await database.queryWithResults('SELECT logchannel FROM servers WHERE serverid = $1', [this.guild.id]);
+		if (res[0].logchannel) {
+			return this.errorReply(`This server is already set up to log to <#${res[0].logchannel}>.`);
 		}
 
-		await this.worker.query('UPDATE servers SET logchannel = $1 WHERE serverid = $2', [this.channel.id, this.guild.id]);
+		await database.query('UPDATE servers SET logchannel = $1 WHERE serverid = $2', [this.channel.id, this.guild.id]);
 		await this.reply('Server events will now be logged to this channel.');
-
-		this.worker.release();
-		this.worker = null;
 	}
 
 	static help(): string {
@@ -392,18 +368,14 @@ export class DisableLogs extends BaseCommand {
 	}
 
 	async execute() {
-		if (!this.guild) return this.errorReply('This command is not mean\'t to be used in PMs.');
+		if (!this.guild) return this.errorReply('This command is not meant to be used in PMs.');
 		if (!(await this.can('MANAGE_GUILD'))) return this.errorReply('Access Denied');
-		this.worker = await pgPool.connect();
 
-		const res = await this.worker.query('SELECT logchannel FROM servers WHERE serverid = $1', [this.guild.id]);
-		if (!res.rows[0].logchannel) return this.errorReply('This server is not setup to log messages to a log channel.');
+		const res = await database.queryWithResults('SELECT logchannel FROM servers WHERE serverid = $1', [this.guild.id]);
+		if (!res[0].logchannel) return this.errorReply('This server is not setup to log messages to a log channel.');
 
-		await this.worker.query('UPDATE servers SET logchannel = $1 WHERE serverid = $2', [null, this.guild.id]);
+		await database.query('UPDATE servers SET logchannel = $1 WHERE serverid = $2', [null, this.guild.id]);
 		await this.reply('Server events will no longer be logged to this channel.');
-
-		this.worker.release();
-		this.worker = null;
 	}
 
 	static help(): string {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,11 +1,13 @@
-import PG = require('pg');
+import * as PG from 'pg';
+import {Database, ExternalPostgresDatabase} from './lib/database';
 
 export type ID = '' | string & {__isID: true};
 
 // The prefix to all bot commands
 export const prefix = process.env.PREFIX || '$';
 
-export const pgPool = new PG.Pool();
+// Typed as Database because in unit tests, this will be changed to a MemoryPostgresDatabase
+export const database: Database = new ExternalPostgresDatabase(new PG.Pool());
 
 /**
  * toID - Turns anything into an ID (string with only lowercase alphanumeric characters)

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,7 +4,7 @@ import {Database, ExternalPostgresDatabase} from './lib/database';
 export type ID = '' | string & {__isID: true};
 
 // The prefix to all bot commands
-export const prefix = process.env.PREFIX || '$';
+export const prefix = process.env.BOT_PREFIX || process.env.PREFIX || '$';
 
 // Typed as Database because in unit tests, this will be changed to a MemoryPostgresDatabase
 export const database: Database = new ExternalPostgresDatabase(new PG.Pool());

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,0 +1,143 @@
+/**
+ * Database access code.
+ *
+ * Porygon-Z currently uses PostgreSQL as its database of choice.
+ * However, it can run using either an external Postgres server, or an in-memory Postgres database provided by pg-mem.
+ * The latter does not support 100% of Postgres' features;
+ * code depending on SQL queries which are incompatible with pg-mem can't be unit tested,
+ * but should theoretically run in production environments (with a real Postgres database).
+ *
+ * Porygon-Z does not currently plan to support other databases, but if it ever does, the code would go here.
+ *
+ * @author Annika
+ */
+import type {Pool} from 'pg';
+import type {IMemoryDb} from 'pg-mem';
+
+import {escape as escapeSQL} from 'sqlutils/pg';
+
+interface Query {
+	statement: string;
+	args?: any[];
+}
+
+export interface Database {
+	/** executes a query that doesn't return results */
+	query(statement: string, args?: any[]): Promise<void>;
+
+	/** executes a query that returns results */
+	queryWithResults(statement: string, args?: any[]): Promise<any[]>;
+
+	/**
+	 * Executes several queries sequentially within a transaction.
+	 *
+	 * @returns true on success and false if an error occurs (in which case the transaction will be rolled back)
+	 */
+	withinTransaction(queries: Query[]): Promise<boolean>;
+
+	destroy(): Promise<void>;
+}
+
+export class ExternalPostgresDatabase implements Database {
+	private pool: Pool;
+
+	constructor(pool: Pool) {
+		this.pool = pool;
+	}
+
+	async query(statement: string, args?: any[]) {
+		await this.pool.query(statement, args);
+	}
+
+	async queryWithResults(statement: string, args?: any[]) {
+		const result = await this.pool.query(statement, args);
+		return result.rows;
+	}
+
+	async withinTransaction(queries: Query[]) {
+		const client = await this.pool.connect();
+		try {
+			await client.query('BEGIN');
+			for (const query of queries) {
+				await client.query(query.statement, query.args);
+			}
+			await client.query('COMMIT');
+
+			return true;
+		} catch (e) {
+			await client.query('ROLLBACK');
+			return false;
+		} finally {
+			client.release();
+		}
+	}
+
+	async destroy() {
+		return this.pool.end();
+	}
+}
+
+export class MemoryPostgresDatabase implements Database {
+	private db: IMemoryDb;
+
+	constructor(db: IMemoryDb) {
+		this.db = db;
+	}
+
+
+	query(statement: string, args?: any[]): Promise<void> {
+		this.db.public.none(this.stringifyQuery(statement, args));
+		return Promise.resolve();
+	}
+
+	queryWithResults(statement: string, args?: any[]): Promise<any[]> {
+		return Promise.resolve(this.db.public.many(this.stringifyQuery(statement, args)));
+	}
+
+	async withinTransaction(queries: Query[]) {
+		try {
+			await this.query('BEGIN');
+			for (const query of queries) {
+				await this.query(query.statement, query.args);
+			}
+			await this.query('COMMIT');
+
+			return true;
+		} catch (e) {
+			await this.query('ROLLBACK');
+			return false;
+		}
+	}
+
+	destroy() {
+		return Promise.resolve();
+	}
+
+	/**
+	 * Converts a Query (representing a parameterized statement) to a string.
+	 * Ideally we wouldn't need to do this, but it shouldn't present too great of a security risk,
+	 * since MemoryPostgresDatabase is only used for unit tests, not in production.
+	 *
+	 * This can be removed when https://github.com/oguimbal/pg-mem/issues/101 is fixed.
+	 */
+	stringifyQuery(statement: string, args?: any[]) {
+		if (!args?.length) return statement;
+
+		// this is a fairly hacky solution - if only pg-mem had built-in parameterization...
+		// basically, we assume any instance of whitespace-"$"-digits is a parameter, and
+		// replace it with the given argument (sanitized, of course!).
+		return statement.replace(/(\s)\$(\d+)/g, (_, precedingWhitespace, indexString) => {
+			const index = parseInt(indexString);
+			if (isNaN(index) || index <= 0 || index > args.length) {
+				throw new Error(`Invalid index for parameterized statement: ${indexString}`);
+			}
+
+			// SQL parameters start as $1, but array indices in JS start at arr[0], so we subtract 1
+			return precedingWhitespace + escapeSQL(args[index - 1].toString());
+		});
+	}
+
+	backup() {
+		return this.db.backup();
+	}
+}

--- a/src/lib/sqlutils.d.ts
+++ b/src/lib/sqlutils.d.ts
@@ -1,0 +1,3 @@
+declare module 'sqlutils/pg' {
+	function escape(statement: string): string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
 		"outDir": "dist",
 		"sourceMap": true,
 		"incremental": true,
-		"strict": true,
-		"esModuleInterop": true
+		"strict": true
 	},
 	"include": [
 		"src/**/*.ts", "globals.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
 		"outDir": "dist",
 		"sourceMap": true,
 		"incremental": true,
-		"strict": true
+		"strict": true,
+		"esModuleInterop": true
 	},
 	"include": [
 		"src/**/*.ts", "globals.ts"


### PR DESCRIPTION
This will let us run unit tests with an in-memory database (and generally be less dependent on a particular database or database library).

Prerequisite to #27.